### PR TITLE
Test 'differential' (ct'd)

### DIFF
--- a/ReinforcementLearning/NHL/playbyplay/shifts.py
+++ b/ReinforcementLearning/NHL/playbyplay/shifts.py
@@ -104,7 +104,7 @@ class LineShifts(object):
         LINES['differential'].append(np.sum(LINES['GOAL']))
 
         # ok, now let's buid it:
-        self.shifts = pd.DataFrame.from_dict(LINES)
+        self.shifts = pd.DataFrame.from_dict(LINES).reset_index()
         # # all done, then:
         # return (team, teams, lineShifts)
 


### PR DESCRIPTION
@YounesZ : second test for `differential` inconsistencies. With these the 2 tests are in place ("_when there is a change in `differential` there should be a change in `goals`_", and the complement) and they are not failing. Can you think of another way to reproduce the bug? 